### PR TITLE
Test & fix for regression in Lazy serialization uncovered by #2325

### DIFF
--- a/interface/src/main/java/xsbti/api/AbstractLazy.java
+++ b/interface/src/main/java/xsbti/api/AbstractLazy.java
@@ -3,11 +3,17 @@
  */
 package xsbti.api;
 
-	import java.io.ObjectStreamException;
+import java.io.ObjectStreamException;
 
 public abstract class AbstractLazy<T> implements Lazy<T>, java.io.Serializable
 {
-	private Object writeReplace() throws ObjectStreamException
+	// `writeReplace` must be `protected`, so that the `Impl` subclass
+	// inherits the serialization override.
+	//
+	// (See source-dependencies/java-analysis-serialization-error, which would
+	//  crash trying to serialize an AbstractLazy, because it pulled in an
+	//  unserializable type eventually.)
+	protected Object writeReplace() throws ObjectStreamException
 	{
 		return new StrictLazy<T>(get());
 	}

--- a/sbt/src/sbt-test/source-dependencies/java-analysis-serialization-error/Outer.java
+++ b/sbt/src/sbt-test/source-dependencies/java-analysis-serialization-error/Outer.java
@@ -1,0 +1,1 @@
+public class Outer { private class T extends Thread {} }

--- a/sbt/src/sbt-test/source-dependencies/java-analysis-serialization-error/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/java-analysis-serialization-error/build.sbt
@@ -1,0 +1,1 @@
+incOptions := incOptions.value.withNameHashing(true).withApiDebug(true)

--- a/sbt/src/sbt-test/source-dependencies/java-analysis-serialization-error/test
+++ b/sbt/src/sbt-test/source-dependencies/java-analysis-serialization-error/test
@@ -1,0 +1,1 @@
+> compile


### PR DESCRIPTION
The crash manifested as a `NotSerializableException`,
because we don't visit the private subtrees of the API graph,
which would previously force all Lazy stubs as a side-effect.
There was a backstop in `AbstractLazy` (`writeReplace`), but
somehow that didn't work.

```
java.io.NotSerializableException: sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl
[...]
 at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:329)
 at xsbt.api.SourceFormat$.writes(SourceFormat.scala:24)
 at xsbt.api.SourceFormat$.writes(SourceFormat.scala:15)
 at sbt.inc.TextAnalysisFormat21661anonfun.apply(TextAnalysisFormat.scala:329)
 at sbt.inc.TextAnalysisFormat21661anonfun.apply(TextAnalysisFormat.scala:329)
 at sbt.inc.TextAnalysisFormat21661anonfun at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.javr$.aggregate(TextAnalysisFormat.scala:18)
 at sbt.inc.TextAnalysisFormat$.objToString(TextAnalysisFormat.scala:329)
 at sbt.inc.TextAnalysisFormat21661anonfun.apply(TextAnalysisFormat.scala:213)
 at sbt.inc.TextAnalysisFormat21661anonfun.apply(TextAnalysisFormat.scala:213)
 at sbt.inc.TextAnalysisFormat21661anonfun21661writeMap.apply(TextAnalysisFormat.scala:381)
 at sbt.inc.TextAnalysisFormat21661anonfun21661writeMap.apply(TextAnalysisFormat.scala:377)
 at scala.collection.mutable.ResizableArray.foreach(Resizable at sbt.inc.TextAnalysisFormalection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:47)
 at sbt.inc.TextAnalysisFormat$.sbt21661writeMap(TextAnalysisFormat.scala:377)
 at sbt.inc.TextAnalysisFormat$.write(TextAnalysisFormat.scala:216)
 at sbt.inc.TextAnalysisFormat21661anonfun.apply(TextAnalysisFormat.scala:64)
 at sbt.inc.TextAnalysisFormat21661anonfun.apply(TextAnalysisFormat.scala:64)
 at sbt.inc.TextAnalysisFormat21661anonfun.apply(TextAnalysisFormat.scala:64)
 at sbt.inc.FormatTimer$.aggregate(TextAnalysisFo at sbt.inc.TextAnalysisFormat21661anonfun.scala:25)
 at sbt.inc.TextAnalysisFormat$.write(TextAnalysisFormat.scala:64)
 at sbt.inc.FileBasedStore21661anon21661anonfun.apply(FileBasedStore.scala:12)
 at sbt.inc.FileBasedStore21661anon21661anonfun.apply(FileBasedStore.scala:12)
 at sbt.Using.apply(Using.scala:24)
 at sbt.inc.FileBasedStore21661anon.set(FileBasedStore.scala:12)
 at sbt.inc.AnalysisStore21661anon.set(AnalysisStore.scala:16)
 at sbt.inc.AnalysisStore21661anon.set(AnalysisStore.scala:27)
 at sbt.Defaults21661anonfun.apply(Defaults.scala:799)
 at sbt.Defaults21661anonfun at sbt.inc.TextAts.scala:793)
 at scala.Function121661anonfun.apply(Function1.scala:47)
 at sbt.21661anonfun21661u2219.apply(TypeFunctions.scala:40)
 at sbt.std.Transform21661anon.work(System.scala:63)
 at sbt.Execute21661anonfun21661anonfun.apply(Execute.scala:226)
 at sbt.Execute21661anonfun21661anonfun.apply(Execute.scala:226)
 at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
 at sbt.Execute.work(Execute.scala:235)
 at sbt.Execute21661anonfun.apply(Exe at sbt.Using.apply(Using.scala:24)
 mit.apply(Execute.scala:226)
 at sbt.ConcurrentRestrictions21661anon21661anonfun.apply(ConcurrentRestrictions.scala:159)
 at sbt.CompletionService21661anon.call(CompletionService.scala:28)
 at java.util.concurrent.FutureTask.innerRun(FutureTask.java:303)
 at java.util.concurrent.FutureTask.run(FutureTask.java:138)
 at java.util.concurrent.Executors.call(Executors.java:439)
 at java.util.concurrent.FutureTask.innerRun(FutureTask.java:303 at sbt.std.Transform21661anon.work(System(FutureTask.java:138)
 at java.util.concurrent.ThreadPoolExecutor.runTask(ThreadPoolExecutor.java:895)
 at java.util.concurrent.ThreadPoolExecutor.run(ThreadPoolExecutor.java:918)
 at java.lang.Thread.run(Thread.java:695)

[error] (compile:compile) java.io.NotSerializableException: sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl
[error] Total time: 2 s, completed Dec 21, 2015 12:05:19 PM
```
